### PR TITLE
Remove unnecessary shebang

### DIFF
--- a/compressed_rtf/compressed_rtf.py
+++ b/compressed_rtf/compressed_rtf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #-*- coding: utf8 -*-
 """
 Compressed Rich Text Format (RTF) worker

--- a/compressed_rtf/crc32.py
+++ b/compressed_rtf/crc32.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #-*- coding: utf8 -*-
 """
 Module for CRC32 calculation


### PR DESCRIPTION
The files do not have executable permissions and are not meant to be run
standalone. Thus, the shebang is obsolete.
