### PR TITLE
Include `LICENSE` and use correct keyword

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
-description-file = README.md
+description_file = README.md
+license_files = LICENSE


### PR DESCRIPTION
The `LICENSE` file is not included in the PyPI tarball. This is a
license requirement as per:

```
The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.
```

Also `description-file` is deprecated. All keywords use underscores now.
