### PR TITLE
Fix issues with building of sdist and wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ setup(
     license='MIT',
     keywords='compressed-rtf lzfu mela rtf',
     url='https://github.com/delimitry/compressed_rtf',
-    packages=['compressed_rtf'],
-    test_suite='tests',
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Specifying `packages` in `setup.py` will exclude everything else from
being distributed on PyPI. However, the test suit should be part of the
`sdist`, but _**not**_ the `wheel`.

Simply removing the `packages` keyword, will allow auto discovery
kicking in, adding the tests to the `sdist`, but _**not**_ the wheel.

Alternatively, the same can be achieved using the `packages_find()`
method of setuptools with an exclude:

```python
packages=setuptools.find_packages(
    exclude=['tests*'],
),
```

The `test_*` keywords are deprecated. See:

https://setuptools.pypa.io/en/latest/references/keywords.html
