### PR TITLE
fix: resolve circular import in setup.py

### DIFF
--- a/compressed_rtf/__init__.py
+++ b/compressed_rtf/__init__.py
@@ -7,9 +7,14 @@ Based on Rich Text Format (RTF) Compression Algorithm
 https://msdn.microsoft.com/en-us/library/cc463890(v=exchg.80).aspx
 """
 
-__title__ = 'compressed_rtf'
-__version__ = '1.0.6'
-__author__ = 'Dmitry Alimov'
-__license__ = 'MIT'
+from .__version__ import (
+    __author__,
+    __description__,
+    __license__,
+    __long_description__,
+    __title__,
+    __url__,
+    __version__,
+)
 
 from .compressed_rtf import compress, decompress

--- a/compressed_rtf/__version__.py
+++ b/compressed_rtf/__version__.py
@@ -1,0 +1,12 @@
+__title__ = 'compressed_rtf'
+__version__ = '1.0.6'
+__author__ = 'Dmitry Alimov'
+__license__ = 'MIT'
+__description__ = 'Compressed Rich Text Format (RTF) compression and decompression package'
+__url__ = 'https://github.com/dmitryalimov/compressed_rtf'
+__long_description__ = """
+Compressed Rich Text Format (RTF) compression and decompression package
+
+Based on Rich Text Format (RTF) Compression Algorithm
+https://msdn.microsoft.com/en-us/library/cc463890(v=exchg.80).aspx
+"""

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,24 @@
 Setup file, used to install and test 'compressed_rtf'
 """
 
-import compressed_rtf
+import os
 from setuptools import setup
 
+about = {}
+here = os.path.abspath(os.path.dirname(__file__))
+
+with open(os.path.join(here, "compressed_rtf", "__version__.py"), "r", encoding = "utf-8") as f:
+    exec(f.read(), about)
+
 setup(
-    name='compressed_rtf',
-    version=compressed_rtf.__version__,
-    author='Dmitry Alimov',
-    description='Compressed Rich Text Format (RTF) compression and decompression package',
-    long_description=compressed_rtf.__doc__.strip(),
-    license='MIT',
+    name=about["__title__"],
+    version=about["__version__"],
+    author=about["__author__"],
+    description=about["__description__"],
+    long_description=about["__long_description__"],
+    license=about["__license__"],
     keywords='compressed-rtf lzfu mela rtf',
-    url='https://github.com/delimitry/compressed_rtf',
+    url=about["__url__"],
     zip_safe=False,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fix circular self-referential import in setup.py

Issue
#18
Directly importing the project's main module in setup.py caused a circular import error (ModuleNotFoundError) during package installation (e.g., python setup.py install or pip install). 

Changes
Extracted metadata into a standalone `__version__.py` file. 
Modified `__init__.py` and `setup,py`
