### PR TITLE
fix pyproject.toml license format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "compressed-rtf"
 dynamic = ["version"]
 description = "Compressed Rich Text Format (RTF) compression and decompression package"
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT"}
 authors = [
     { name = "Dmitry Alimov" },
 ]


### PR DESCRIPTION
at least with some versions of setuptools, an error is thrown with the license line in pyproject.toml in 1.0.7;

```
* Getting build dependencies for wheel...                                                                             
configuration error: `project.license` must be valid exactly by one definition (2 matches found):                     
                                                                                                                      
    - keys:                                                                                                           
        'file': {type: string}                                                                                        
      required: ['file']                                                                                              
    - keys:                                                                                                           
        'text': {type: string}                                                                                        
      required: ['text']                                                                                              
```

this PR fixes it.